### PR TITLE
Comply with a rule from ansible-lint 4.0.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,7 @@
   package:
     name: '{{ item }}'
     state: present
+  register: package_installs
+  until: package_installs is success
+  retries: 10
+  delay: 2


### PR DESCRIPTION
[405] Remote package tasks should have a retry
andrewrothstein.unarchive-deps/tasks/main.yml:13
Task/Handler: install common pkgs...